### PR TITLE
Modify CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing to Eidetica
+## Contributing to Spellbook
 
 You want to contribute to the project? Awesome!
 
@@ -29,26 +29,23 @@ I recommend using [Yarn](https://yarnpkg.com/en/) since I try to keep the `yarn.
 
 1. Clone the repo
   ```
-  git clone git@github.com:trezy/dnd.git
-  cd eidetica
+  git clone git@github.com:your-username/dnd.git
   ```
-1. Install dependencies
+2. Install dependencies
   ```shell
   yarn install
   # or
   npm install
   ```
-1. Run the app
+3. If you're doing styling changes, you'll want to run the `scss-build` script in the background to keep your styles up-to-date:
+  ```shell
+  yarn run scss-build
+  # or
+  npm run scss-build
+  ```
+4. Run the app
   ```shell
   yarn run dev
   # or
   npm run dev
   ```
-
-If you're doing styling shanges, you'll want to run the `scss-build` script to keep your styles up-to-date:
-
-```shell
-yarn run scss-build
-# or
-npm run scss-build
-```


### PR DESCRIPTION
Change title from Eidetica to Spellbook.
Correct numbers of the steps in 'getting up and running'.
Fix typos.  Reorder 'getting up and running' so that
running the scss-build script comes before 'yarn run dev'.
Inform the user that the scss-build script will run in the background.